### PR TITLE
tSNR: change value of last scan if dynNOISEScan = 1

### DIFF
--- a/offlineQA/tSNR.m
+++ b/offlineQA/tSNR.m
@@ -63,6 +63,11 @@ nV = size(Data,4);
 if dynNOISEscan==1
     im_data=Data(:,:,:,1:nV-1);
     noise_data=Data(:,:,:,nV);
+    if(~isempty(cropTimeSeries))
+        if cropTimeSeries(2) == nV
+            cropTimeSeries(2) = cropTimeSeries(2)-1;
+        end
+    end
 else
     im_data=Data;
     noise_data = zeros(nX,nY,nS);


### PR DESCRIPTION
Fixes a bug when dynNOISEScan = 1 and the 'Last scan' is set to the last dynamic. Sets the last scan to be the last dynamic minus one.
